### PR TITLE
Fix: AttachedSticker.kt attachedId 관련 버그 수정 및 리팩토링

### DIFF
--- a/src/main/kotlin/com/mashup/eclassserver/model/dto/AttachedStickerDto.kt
+++ b/src/main/kotlin/com/mashup/eclassserver/model/dto/AttachedStickerDto.kt
@@ -1,6 +1,6 @@
 package com.mashup.eclassserver.model.dto
 
-data class AttachedStickerSubmitRequest(
+data class AttachedStickerDto(
     val stickerId: Long,
     val stickerX: Double,
     val stickerY: Double

--- a/src/main/kotlin/com/mashup/eclassserver/model/dto/CoverRegisterRequestDto.kt
+++ b/src/main/kotlin/com/mashup/eclassserver/model/dto/CoverRegisterRequestDto.kt
@@ -2,7 +2,6 @@ package com.mashup.eclassserver.model.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.mashup.eclassserver.model.entity.ShapeType
-import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.multipart.MultipartFile
 import java.time.LocalDate
 
@@ -18,12 +17,6 @@ data class CoverData(
     val shapeX: Double,
     val shapeY: Double,
 
-    @JsonFormat( pattern = "yyyy-MM-dd")
+    @JsonFormat(pattern = "yyyy-MM-dd")
     val targetDate: LocalDate
-)
-
-data class AttachedStickerDto(
-    val stickerId: Long,
-    val stickerX: Double,
-    val stickerY: Double
 )

--- a/src/main/kotlin/com/mashup/eclassserver/model/dto/PictureSubmitRequest.kt
+++ b/src/main/kotlin/com/mashup/eclassserver/model/dto/PictureSubmitRequest.kt
@@ -3,5 +3,5 @@ package com.mashup.eclassserver.model.dto
 data class PictureSubmitRequest(
     val imageUrl: String,
     val isThumbnail: Boolean,
-    val attachedStickerSubmitRequestList: List<AttachedStickerSubmitRequest>
+    val attachedStickerDtoList: List<AttachedStickerDto>
 )

--- a/src/main/kotlin/com/mashup/eclassserver/model/entity/AttachedSticker.kt
+++ b/src/main/kotlin/com/mashup/eclassserver/model/entity/AttachedSticker.kt
@@ -1,6 +1,7 @@
 package com.mashup.eclassserver.model.entity
 
 import com.mashup.eclassserver.model.dto.AttachedStickerDto
+import com.mashup.eclassserver.model.dto.AttachedStickerSubmitRequest
 import javax.persistence.*
 
 @Entity
@@ -10,9 +11,9 @@ data class AttachedSticker(
     val stickerId: Long,
     val attachedId: Long,
     val memberId: Long,
-    @Column(name ="sticker_x")
+    @Column(name = "sticker_x")
     val stickerX: Double,
-    @Column(name ="sticker_y")
+    @Column(name = "sticker_y")
     val stickerY: Double,
     @Enumerated(EnumType.STRING)
     val attachedType: AttachedType
@@ -26,6 +27,17 @@ data class AttachedSticker(
                 stickerX = attachedStickerDto.stickerX,
                 stickerY = attachedStickerDto.stickerY,
                 attachedType = AttachedType.COVER
+            )
+        }
+
+        fun of(memberId: Long, request: AttachedStickerSubmitRequest, diaryId: Long): AttachedSticker {
+            return AttachedSticker(
+                memberId = memberId,
+                stickerId = request.stickerId,
+                attachedId = diaryId,
+                stickerX = request.stickerX,
+                stickerY = request.stickerY,
+                attachedType = AttachedType.DIARY
             )
         }
     }

--- a/src/main/kotlin/com/mashup/eclassserver/model/entity/AttachedSticker.kt
+++ b/src/main/kotlin/com/mashup/eclassserver/model/entity/AttachedSticker.kt
@@ -1,7 +1,6 @@
 package com.mashup.eclassserver.model.entity
 
 import com.mashup.eclassserver.model.dto.AttachedStickerDto
-import com.mashup.eclassserver.model.dto.AttachedStickerSubmitRequest
 import javax.persistence.*
 
 @Entity
@@ -19,25 +18,14 @@ data class AttachedSticker(
     val attachedType: AttachedType
 ) : BaseEntity() {
     companion object {
-        fun of(memberId: Long, coverId: Long, attachedStickerDto: AttachedStickerDto): AttachedSticker {
+        fun of(memberId: Long, attachedId: Long, type: AttachedType, attachedStickerDto: AttachedStickerDto): AttachedSticker {
             return AttachedSticker(
                 memberId = memberId,
                 stickerId = attachedStickerDto.stickerId,
-                attachedId = coverId,
+                attachedId = attachedId,
                 stickerX = attachedStickerDto.stickerX,
                 stickerY = attachedStickerDto.stickerY,
-                attachedType = AttachedType.COVER
-            )
-        }
-
-        fun of(memberId: Long, request: AttachedStickerSubmitRequest, diaryId: Long): AttachedSticker {
-            return AttachedSticker(
-                memberId = memberId,
-                stickerId = request.stickerId,
-                attachedId = diaryId,
-                stickerX = request.stickerX,
-                stickerY = request.stickerY,
-                attachedType = AttachedType.DIARY
+                attachedType = type
             )
         }
     }

--- a/src/main/kotlin/com/mashup/eclassserver/model/entity/DiaryPicture.kt
+++ b/src/main/kotlin/com/mashup/eclassserver/model/entity/DiaryPicture.kt
@@ -11,21 +11,13 @@ data class DiaryPicture(
 
     val imageUrl: String,
 
-    val isThumbnail: Boolean,
-
-    @OneToMany(fetch = FetchType.LAZY, cascade = arrayOf(CascadeType.ALL))
-    @JoinColumn(name = "attached_id")
-    var attachedStickerList: MutableList<AttachedSticker>
+    val isThumbnail: Boolean
 ) : BaseEntity() {
     companion object {
-        fun of(request: PictureSubmitRequest, memberId: Long) =
+        fun of(request: PictureSubmitRequest) =
                 DiaryPicture(
                     imageUrl = request.imageUrl,
-                    isThumbnail = request.isThumbnail,
-                    attachedStickerList =
-                    request.attachedStickerSubmitRequestList.asSequence()
-                            .map { AttachedSticker.of(it, memberId) }
-                            .toMutableList()
+                    isThumbnail = request.isThumbnail
                 )
     }
 }

--- a/src/main/kotlin/com/mashup/eclassserver/service/CoverService.kt
+++ b/src/main/kotlin/com/mashup/eclassserver/service/CoverService.kt
@@ -1,8 +1,8 @@
 package com.mashup.eclassserver.service
 
 import com.mashup.eclassserver.model.dto.CoverData
-import com.mashup.eclassserver.model.dto.CoverRegisterRequestDto
 import com.mashup.eclassserver.model.entity.AttachedSticker
+import com.mashup.eclassserver.model.entity.AttachedType
 import com.mashup.eclassserver.model.entity.Cover
 import com.mashup.eclassserver.model.repository.AttachedStickerRepository
 import com.mashup.eclassserver.model.repository.CoverRepository
@@ -33,7 +33,7 @@ class CoverService(
         )
 
         val attachedStickerList = coverData.attachedStickerList.map {
-            AttachedSticker.of(memberId, cover.coverId, it)
+            AttachedSticker.of(memberId, cover.coverId, AttachedType.COVER, it)
         }
 
         attachedStickerRepository.saveAll(attachedStickerList)

--- a/src/main/kotlin/com/mashup/eclassserver/service/DiaryService.kt
+++ b/src/main/kotlin/com/mashup/eclassserver/service/DiaryService.kt
@@ -1,21 +1,47 @@
 package com.mashup.eclassserver.service
 
 import com.mashup.eclassserver.model.dto.DiarySubmitRequest
+import com.mashup.eclassserver.model.entity.AttachedSticker
 import com.mashup.eclassserver.model.entity.Diary
 import com.mashup.eclassserver.model.entity.DiaryPicture
 import com.mashup.eclassserver.model.entity.Member
+import com.mashup.eclassserver.model.repository.AttachedStickerRepository
 import com.mashup.eclassserver.model.repository.DiaryRepository
 import org.springframework.stereotype.Service
 import javax.transaction.Transactional
 
 @Service
-class DiaryService(private val diaryRepository: DiaryRepository) {
+class DiaryService(
+    private val diaryRepository: DiaryRepository,
+    private val attachedStickerRepository: AttachedStickerRepository
+) {
     @Transactional
     fun submitDiary(diarySubmitRequest: DiarySubmitRequest, member: Member) {
+        val diary = saveDiaryWithPictureList(diarySubmitRequest, member)
+        saveAttachedStickerList(diarySubmitRequest, diary, member)
+    }
+
+    private fun saveDiaryWithPictureList(diarySubmitRequest: DiarySubmitRequest, member: Member): Diary {
         val diary = Diary.of(diarySubmitRequest, member)
-        diary.diaryPictureList.addAll(diarySubmitRequest.pictureSubmitRequestList.asSequence()
-                                              .map { DiaryPicture.of(it, member.memberId) }
-                                              .toMutableList())
-        diaryRepository.save(diary)
+        val diaryPictureList = diarySubmitRequest.pictureSubmitRequestList
+                .asSequence()
+                .map { DiaryPicture.of(it) }
+                .toMutableList()
+        diary.diaryPictureList.addAll(diaryPictureList)
+        return diaryRepository.save(diary)
+    }
+
+    private fun saveAttachedStickerList(diarySubmitRequest: DiarySubmitRequest, diary: Diary, member: Member) {
+        val attachedStickerList = diarySubmitRequest.pictureSubmitRequestList
+                .flatMap {
+                    it.attachedStickerSubmitRequestList
+                            .asSequence()
+                            .map {
+                                AttachedSticker.of(member.memberId, it, diary.diaryId)
+                            }
+                            .toMutableList()
+                }
+
+        attachedStickerRepository.saveAll(attachedStickerList)
     }
 }

--- a/src/main/kotlin/com/mashup/eclassserver/service/DiaryService.kt
+++ b/src/main/kotlin/com/mashup/eclassserver/service/DiaryService.kt
@@ -1,10 +1,7 @@
 package com.mashup.eclassserver.service
 
 import com.mashup.eclassserver.model.dto.DiarySubmitRequest
-import com.mashup.eclassserver.model.entity.AttachedSticker
-import com.mashup.eclassserver.model.entity.Diary
-import com.mashup.eclassserver.model.entity.DiaryPicture
-import com.mashup.eclassserver.model.entity.Member
+import com.mashup.eclassserver.model.entity.*
 import com.mashup.eclassserver.model.repository.AttachedStickerRepository
 import com.mashup.eclassserver.model.repository.DiaryRepository
 import org.springframework.stereotype.Service
@@ -34,10 +31,10 @@ class DiaryService(
     private fun saveAttachedStickerList(diarySubmitRequest: DiarySubmitRequest, diary: Diary, member: Member) {
         val attachedStickerList = diarySubmitRequest.pictureSubmitRequestList
                 .flatMap {
-                    it.attachedStickerSubmitRequestList
+                    it.attachedStickerDtoList
                             .asSequence()
                             .map {
-                                AttachedSticker.of(member.memberId, it, diary.diaryId)
+                                AttachedSticker.of(member.memberId, diary.diaryId, AttachedType.DIARY, it)
                             }
                             .toMutableList()
                 }

--- a/src/test/kotlin/com/mashup/eclassserver/controller/DiaryControllerTest.kt
+++ b/src/test/kotlin/com/mashup/eclassserver/controller/DiaryControllerTest.kt
@@ -1,7 +1,7 @@
 package com.mashup.eclassserver.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.mashup.eclassserver.model.dto.AttachedStickerSubmitRequest
+import com.mashup.eclassserver.model.dto.AttachedStickerDto
 import com.mashup.eclassserver.model.dto.DiarySubmitRequest
 import com.mashup.eclassserver.model.dto.PictureSubmitRequest
 import com.mashup.eclassserver.model.entity.Member
@@ -38,7 +38,7 @@ class DiaryControllerTest @Autowired constructor(
                     "testImgUrl.com",
                     false,
                     arrayListOf(
-                        AttachedStickerSubmitRequest(
+                        AttachedStickerDto(
                             1, 33.3, 44.4
                         )
                     )
@@ -71,13 +71,13 @@ class DiaryControllerTest @Autowired constructor(
                                     .description("사진 이미지"),
                             PayloadDocumentation.fieldWithPath("pictureSubmitRequestList[*].thumbnail")
                                     .description("썸네일 여부"),
-                            PayloadDocumentation.fieldWithPath("pictureSubmitRequestList[*].attachedStickerSubmitRequestList")
+                            PayloadDocumentation.fieldWithPath("pictureSubmitRequestList[*].attachedStickerDtoList")
                                     .description("스티커 정보"),
-                            PayloadDocumentation.fieldWithPath("pictureSubmitRequestList[*].attachedStickerSubmitRequestList[*].stickerId")
+                            PayloadDocumentation.fieldWithPath("pictureSubmitRequestList[*].attachedStickerDtoList[*].stickerId")
                                     .description("스티커 아이디"),
-                            PayloadDocumentation.fieldWithPath("pictureSubmitRequestList[*].attachedStickerSubmitRequestList[*].stickerX")
+                            PayloadDocumentation.fieldWithPath("pictureSubmitRequestList[*].attachedStickerDtoList[*].stickerX")
                                     .description("스티커 x 좌표 비율"),
-                            PayloadDocumentation.fieldWithPath("pictureSubmitRequestList[*].attachedStickerSubmitRequestList[*].stickerY")
+                            PayloadDocumentation.fieldWithPath("pictureSubmitRequestList[*].attachedStickerDtoList[*].stickerY")
                                     .description("스티커 y 좌표 비율"),
                         )
                     )


### PR DESCRIPTION
## 개요
AttachedSticker 엔티티에서 종현, 종민 설계 충돌
종민 버전: attachedId 없고, Diary에서 AttachedStickerList를 OneToMany로 가지고 있음
종현 버전: attachedId 있고, Cover에서 AttachedStickerList를 가지고 있지 않고, 수동으로 AttachedStickerList를 저장해줌(addAll)

회의 때, enum(COVER, DIARY)로 인해서 AttachedSticker는 jpa가 아니라 querydsl로 가져오기로 했으므로 종현이형이 해놓은 것이 맞는 코드이므로 내 코드 수정

## 작업 내용
- AttachedSticker.of 메소드 수정
- submitDiary 메소드 비즈니스 로직 수정
- submitDiary 메소드 리팩토링

## 주의사항
