### PR TITLE
Feat: S3Supporter 기능 설정 및 폴더별 파일 업로드 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,8 @@ dependencies {
 
     asciidoctor("org.springframework.restdocs:spring-restdocs-asciidoctor")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
+
+    implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.1.RELEASE")
 }
 
 tasks {

--- a/src/main/kotlin/com/mashup/eclassserver/config/AwsConfig.kt
+++ b/src/main/kotlin/com/mashup/eclassserver/config/AwsConfig.kt
@@ -1,0 +1,31 @@
+package com.mashup.eclassserver.config
+
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class AwsS3Config(
+    @Value("\${cloud.aws.credentials.access-key}")
+    private val accessKey: String,
+
+    @Value("\${cloud.aws.credentials.secret-key}")
+    private val secretKey: String,
+
+    @Value("\${cloud.aws.region.static}")
+    private val region: String,
+) {
+    @Bean
+    fun awsS3Client(): AmazonS3 {
+        val credentials: AWSCredentials = BasicAWSCredentials(accessKey, secretKey)
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build()
+    }
+}

--- a/src/main/kotlin/com/mashup/eclassserver/service/CoverService.kt
+++ b/src/main/kotlin/com/mashup/eclassserver/service/CoverService.kt
@@ -20,7 +20,7 @@ class CoverService(
 
     @Transactional
     fun register(memberId: Long, petId: Long, coverData: CoverData, imageFile: MultipartFile) {
-        val imageUrl = s3Supporter.transmit(imageFile)
+        val imageUrl = s3Supporter.transmit(imageFile, S3Supporter.COVERS)
         val cover = coverRepository.save(
             Cover(
                 petId = petId,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,7 @@
 spring.profiles.active=local
 server.port=1030
+cloud.aws.credentials.access-key=${accessKey}
+cloud.aws.credentials.secret-key=${secretKey}
+cloud.aws.s3.bucket=eclass-bucket
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto=false


### PR DESCRIPTION
## 개요
S3Supporter 기능 설정 및 폴더별 파일 업로드 구현

## 작업 내용
- S3Supporter의 transmit 메소드 구현
- AWSConfig 설정 및 application.properties 설정
- 원격 서버 server.jongheyon.com의 환경변수에 accesskey, secretKey 등록
- S3는 폴더별로 구분하도록 하였고, transmit할 때 상수로 type을 입력받으면 type별로 폴더에 쏙쏙 들어가게 구현
![image](https://user-images.githubusercontent.com/46064193/136686603-2c5ca6b8-c0c3-4dc1-b7e3-dd77a46768ce.png)
----
![image](https://user-images.githubusercontent.com/46064193/136686613-f08d4677-1e0f-41d6-afec-401651e79549.png)

- S3 폴더 구조
![image](https://user-images.githubusercontent.com/46064193/136686591-bac156fd-6c93-46af-8481-790b6c8cac5b.png)


## 주의사항
- 각자 intellij 환경변수에 accessKey, secretKey 등록하여 사용할 것(구체적 내용은 카톡으로 알림)
- POSTMAN으로 MultipartFile과 json 혼합 테스트 방법
![image](https://user-images.githubusercontent.com/46064193/136686660-bcd4fe91-ac1f-4d7d-8c7c-49d83a1e521e.png)