### PR TITLE
Diary 엔티티에 replyList 추가

### DIFF
--- a/src/main/kotlin/com/mashup/eclassserver/model/entity/Diary.kt
+++ b/src/main/kotlin/com/mashup/eclassserver/model/entity/Diary.kt
@@ -24,7 +24,11 @@ data class Diary(
 
     @OneToMany(fetch = FetchType.LAZY, cascade = arrayOf(CascadeType.ALL))
     @JoinColumn(name = "diary_id")
-    var diaryPictureList: MutableList<DiaryPicture> = mutableListOf()
+    var diaryPictureList: MutableList<DiaryPicture> = mutableListOf(),
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = arrayOf(CascadeType.ALL), orphanRemoval = true)
+    @JoinColumn(name = "diary_id")
+    var replyList: MutableList<Reply> = mutableListOf()
 ) : BaseEntity(){
     companion object{
         fun of(request: DiarySubmitRequest, member: Member) =


### PR DESCRIPTION
## 개요
Diary 엔티티에 replyList 추가
## 작업 내용
Diary 엔티티에 onetomany, cascade all, orphanremoval=true로 replyList 추가
댓글 작성 및 조회 API는 이미 작성한 상태이므로 추가 X
## 주의사항
